### PR TITLE
matplotlib

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,51 +1,72 @@
 #!/usr/bin/env python3
 
-# load json and create model
 from __future__ import division
-from keras.models import Sequential
-from keras.layers import Dense
+import tensorflow as tf
 from keras.models import model_from_json
-import numpy
-import os
 import sys
 import numpy as np
 import cv2
 from matplotlib import pyplot as plt
+import matplotlib.patches as patches
+
+
+# disable Tensorflow warnings
+tf.logging.set_verbosity(tf.logging.ERROR)
 
 # loading the model
 json_file = open('fer.json', 'r')
 loaded_model_json = json_file.read()
 json_file.close()
 loaded_model = model_from_json(loaded_model_json)
+
 # load weights into new model
 loaded_model.load_weights("fer.h5")
-print("Loaded model from disk")
+print("Loaded model from disk.")
 
 # setting image resizing parameters
 WIDTH = 48
 HEIGHT = 48
 x = None
 y = None
+
+# defining labels
 labels = ['Angry', 'Disgust', 'Fear', 'Happy', 'Sad', 'Surprise', 'Neutral']
 
-# loading image
+# loading image and convert to gray
 full_size_image = cv2.imread(sys.argv[1])  # second cli argument is the image!
 print("Image loaded: " + sys.argv[1])
 gray = cv2.cvtColor(full_size_image, cv2.COLOR_RGB2GRAY)
+
+# detect face(s)
 face = cv2.CascadeClassifier('haarcascade_frontalface_default.xml')
 faces = face.detectMultiScale(gray, 1.3, 10)
+print(str(len(faces)) + " face(s) detected.")
 
-# detecting faces
+# convert cv2's BGR to matplotlib's RGB system
+full_size_image = full_size_image[:, :, ::-1]
+
+# create figure and axes
+fig, ax = plt.subplots(1)
+
+# Display image
+ax.imshow(full_size_image)
+
+# operate on each detected face
 for (x, y, w, h) in faces:
     roi_gray = gray[y:y + h, x:x + w]
     cropped_img = np.expand_dims(np.expand_dims(cv2.resize(roi_gray, (48, 48)), -1), 0)
     cv2.normalize(cropped_img, cropped_img, alpha=0, beta=1, norm_type=cv2.NORM_L2, dtype=cv2.CV_32F)
-    cv2.rectangle(full_size_image, (x, y), (x + w, y + h), (0, 255, 0), 1)
-    # predicting the emotion
-    yhat = loaded_model.predict(cropped_img)
-    cv2.putText(full_size_image, labels[int(np.argmax(yhat))], (x, y), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 1, cv2.LINE_AA)
-    print("Emotion: " + labels[int(np.argmax(yhat))])
 
-full_size_image = full_size_image[:, :, ::-1]  # converts cv2's BGR to matplotlib's RGB system
-plt.imshow(full_size_image)
+    # draw rectangle around each face
+    rect = patches.Rectangle((x, y), w, h, linewidth=1, edgecolor='r', facecolor='none')
+    ax.add_patch(rect)
+
+    # classify emotion
+    yhat = loaded_model.predict(cropped_img)
+    emotion = labels[int(np.argmax(yhat))]
+
+    # print result in image plot and command line
+    plt.text(x, y, emotion, fontsize=16, color='red')
+    print("Emotion: " + emotion)
+
 plt.show()

--- a/cli.py
+++ b/cli.py
@@ -10,6 +10,7 @@ import os
 import sys
 import numpy as np
 import cv2
+from matplotlib import pyplot as plt
 
 # loading the model
 json_file = open('fer.json', 'r')
@@ -45,5 +46,6 @@ for (x, y, w, h) in faces:
     cv2.putText(full_size_image, labels[int(np.argmax(yhat))], (x, y), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 1, cv2.LINE_AA)
     print("Emotion: " + labels[int(np.argmax(yhat))])
 
-cv2.imshow('Emotion', full_size_image)
-cv2.waitKey()
+full_size_image = full_size_image[:, :, ::-1]  # converts cv2's BGR to matplotlib's RGB system
+plt.imshow(full_size_image)
+plt.show()


### PR DESCRIPTION
Switch all GUI functionality of `opencv-python` to `matplotlib`. Reason is a known issue with `opencv-python`'s GUI code, see https://github.com/skvark/opencv-python/issues/46.